### PR TITLE
Added an option to memory.js so that outputs can be in a different directory

### DIFF
--- a/docs/memory.md
+++ b/docs/memory.md
@@ -40,6 +40,7 @@ The optional `options` object has the following default values:
 
 ```javascript
 {
+    dir: '',
     initialPostGcSleep: 2500,
     finalPostTestSleep: 1500,
     finalPostGcSleep: 4500,
@@ -53,6 +54,7 @@ The optional `options` object has the following default values:
 }
 ```
 
+* `dir`: Directory to output reports. Defaults to current directory.
 * `initialPostGcSleep`: Timeout in milliseconds after the initial garbage collection.
 * `finalPostTestSleep`: Timeout in milliseconds after the final test execution.
 * `finalPostGcSleep`: Timeout in milliseconds after the final garbage collection.
@@ -95,12 +97,14 @@ The optional `options` object has the following default values:
 
 ```javascript
 {
+    dir: '',
     writeLogFile: true,
     writeCsvFile: true,
     generateGraph: true
 }
 ```
 
+* `dir`: Directory to output reports. Defaults to current directory.
 * `writeLogFile`: Enable/disable writing memory results to a log file.
 * `writeCsvFile`: Enable/disable writing memory results to a CSV file.
 * `generateGraph`: Enable/disable generating memory results graph to a PNG file.

--- a/lib/memory.js
+++ b/lib/memory.js
@@ -4,6 +4,7 @@
 
 'use strict';
 var fs = require('fs');
+var path = require('path');
 var mkdirp = require('mkdirp');
 var _ = require('underscore');
 var color = require('cli-color');
@@ -50,7 +51,7 @@ module.exports.startMemoryMeasurement = function (test, options, time, graphData
         options = options || {};
 
         _.defaults(options, {
-            dir: './docs/memory',
+            dir: '',
             writeLogFile: true,
             writeCsvFile: true,
             generateGraph: true,
@@ -63,9 +64,10 @@ module.exports.startMemoryMeasurement = function (test, options, time, graphData
         // Try to create the directory first
         mkdirp.sync(options.dir);
 
-        var filename = options.dir + 'M_' + test.description.replace(/\W/gi, '-') + '_' + time + '.txt';
-        var csvFilename = options.dir + 'M_' + test.description.replace(/\W/gi, '-') + '_' + time + '.csv';
-        var graphFilename = options.dir + 'M_' + test.description.replace(/\W/gi, '-') + '_' + time + '.png';
+        var baseFileName = path.join(options.dir, 'M_' + test.description.replace(/\W/gi, '-') + '_' + time);
+        var filename =  baseFileName + '.txt';
+        var csvFilename = baseFileName + '.csv';
+        var graphFilename = baseFileName + '.png';
 
         if (options.writeLogFile) {
             console.log('Started memory test, logging to file ' + filename);
@@ -128,6 +130,7 @@ module.exports.startMemoryMeasurement = function (test, options, time, graphData
  * @param options Plain object specifying behavior
  *                Default options object:
  *                {
+ *                  dir: '', // Directory to output reports. Defaults to current directory.
  *                  initialPostGcSleep: 2500, // Milliseconds to sleep after GC before iterations start
  *                  finalPostTestSleep: 1500, // Milliseconds to sleep before final GC after all iterations happened
  *                  finalPostGcSleep: 4500, // Milliseconds to sleep between last GC and final memory measurement
@@ -143,6 +146,7 @@ module.exports.startMemoryMeasurement = function (test, options, time, graphData
 module.exports.runTestFunction = function (test, iterations, testFn, options) {
     options = options || {};
     _.defaults(options, {
+        dir: '',
         initialPostGcSleep: 2500,
         finalPostTestSleep: 1500,
         finalPostGcSleep: 4500,

--- a/lib/memory.js
+++ b/lib/memory.js
@@ -4,6 +4,7 @@
 
 'use strict';
 var fs = require('fs');
+var mkdirp = require('mkdirp');
 var _ = require('underscore');
 var color = require('cli-color');
 var generateGraph = require('./graph.js');
@@ -49,6 +50,7 @@ module.exports.startMemoryMeasurement = function (test, options, time, graphData
         options = options || {};
 
         _.defaults(options, {
+            dir: './docs/memory',
             writeLogFile: true,
             writeCsvFile: true,
             generateGraph: true,
@@ -58,9 +60,12 @@ module.exports.startMemoryMeasurement = function (test, options, time, graphData
 
         var memoryResult, initialResult;
 
-        var filename = 'M_' + test.description.replace(/\W/gi, '-') + '_' + time + '.txt';
-        var csvFilename = 'M_' + test.description.replace(/\W/gi, '-') + '_' + time + '.csv';
-        var graphFilename = 'M_' + test.description.replace(/\W/gi, '-') + '_' + time + '.png';
+        // Try to create the directory first
+        mkdirp.sync(options.dir);
+
+        var filename = options.dir + 'M_' + test.description.replace(/\W/gi, '-') + '_' + time + '.txt';
+        var csvFilename = options.dir + 'M_' + test.description.replace(/\W/gi, '-') + '_' + time + '.csv';
+        var graphFilename = options.dir + 'M_' + test.description.replace(/\W/gi, '-') + '_' + time + '.png';
 
         if (options.writeLogFile) {
             console.log('Started memory test, logging to file ' + filename);

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
   "dependencies": {
     "cli-color": "^1.0.0",
     "d3": "^3.5.5",
+    "mkdirp": "^0.5.1",
     "phantom": "^0.7.2",
     "phantomjs": "^1.9.16",
     "requireindex": "^1.1.0",


### PR DESCRIPTION
Hey guys,

This is a simple change that will make it a little easier to keep all the output files in a different directory. 

Keep up the good work!
- Default directory is "./docs/memory"
- Used mkdirp prevent any issues with when trying to create the directory
