### PR TITLE
(bug) Removed deprecated "await" from memory.js

### DIFF
--- a/lib/memory.js
+++ b/lib/memory.js
@@ -82,7 +82,7 @@ module.exports.startMemoryMeasurement = function (test, options, time, graphData
             }
 
             if (graphFilename && options.generateGraph) {
-                browser.controlFlow().await(
+                browser.controlFlow().wait(
                     generateGraph.phantomRender(graphFilename, graphData, options.graphWidth, options.graphHeight)
                 ).then(function () {
                         console.log('Graph generated: ' + graphFilename);


### PR DESCRIPTION
- `browser.controlFlow().await()` is deprecated -- use `wait()`
- Otherwise, fails in protractor v2.5.1
- Seems these functions are the same.
